### PR TITLE
Apply theme styling to issue list columns

### DIFF
--- a/app/views/issue_todo_lists/_items.html.erb
+++ b/app/views/issue_todo_lists/_items.html.erb
@@ -1,7 +1,7 @@
 <% @todo_list_items.each do |item|%>
   <tr id="issue-todo-list-item-<%= item.id %>" class="<%= cycle 'odd', 'even' %>">
     <% @issue_query.columns.each do |column| %>
-      <td><%= column_content(column, item.issue) %></td>
+      <td class="<%= column.name.to_s %>"><%= column_content(column, item.issue) %></td>
     <% end %>
     <% if User.current.allowed_to?(:remove_issue_todo_list_items, @project) %>
       <td>


### PR DESCRIPTION
The most important impact of this change is that it causes the subject column to become left-aligned instead of centered in a number of themes. But more generally it makes the table formatting look the same as the built-in issues table looks like in that theme.